### PR TITLE
Prefix and Suffix Translation #29217

### DIFF
--- a/app/code/Magento/Customer/Block/Address/Renderer/DefaultRenderer.php
+++ b/app/code/Magento/Customer/Block/Address/Renderer/DefaultRenderer.php
@@ -189,6 +189,8 @@ class DefaultRenderer extends AbstractBlock implements RendererInterface
                         $data[$key] = $v;
                     }
                 }
+                if (in_array($attributeCode, ['prefix', 'suffix']))
+                    $value = __($value);
                 $data[$attributeCode] = $value;
             }
         }

--- a/app/code/Magento/Customer/Helper/View.php
+++ b/app/code/Magento/Customer/Helper/View.php
@@ -41,7 +41,7 @@ class View extends \Magento\Framework\App\Helper\AbstractHelper implements Custo
         $name = '';
         $prefixMetadata = $this->_customerMetadataService->getAttributeMetadata('prefix');
         if ($prefixMetadata->isVisible() && $customerData->getPrefix()) {
-            $name .= $customerData->getPrefix() . ' ';
+            $name .= __($customerData->getPrefix()) . ' ';
         }
 
         $name .= $customerData->getFirstname();
@@ -55,7 +55,7 @@ class View extends \Magento\Framework\App\Helper\AbstractHelper implements Custo
 
         $suffixMetadata = $this->_customerMetadataService->getAttributeMetadata('suffix');
         if ($suffixMetadata->isVisible() && $customerData->getSuffix()) {
-            $name .= ' ' . $customerData->getSuffix();
+            $name .= ' ' . __($customerData->getSuffix());
         }
         return $name;
     }

--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -194,7 +194,7 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
     {
         $name = '';
         if ($this->_eavConfig->getAttribute('customer_address', 'prefix')->getIsVisible() && $this->getPrefix()) {
-            $name .= $this->getPrefix() . ' ';
+            $name .= __($this->getPrefix()) . ' ';
         }
         $name .= $this->getFirstname();
         $middleName = $this->_eavConfig->getAttribute('customer_address', 'middlename');
@@ -203,7 +203,7 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
         }
         $name .= ' ' . $this->getLastname();
         if ($this->_eavConfig->getAttribute('customer_address', 'suffix')->getIsVisible() && $this->getSuffix()) {
-            $name .= ' ' . $this->getSuffix();
+            $name .= ' ' . __($this->getSuffix());
         }
         return $name;
     }

--- a/app/code/Magento/Customer/Model/Options.php
+++ b/app/code/Magento/Customer/Model/Options.php
@@ -101,7 +101,8 @@ class Options
         $result = [];
         $options = explode(';', $options);
         foreach ($options as $value) {
-            $result[] = $this->escaper->escapeHtml(trim($value)) ?: ' ';
+            $value = $this->escaper->escapeHtml(trim($value)) ?: ' ';
+            $result[] = __($value);
         }
 
         if ($isOptional && trim(current($options))) {

--- a/app/code/Magento/Sales/Model/Order/Address.php
+++ b/app/code/Magento/Sales/Model/Order/Address.php
@@ -142,7 +142,7 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
     {
         $name = '';
         if ($this->getPrefix()) {
-            $name .= $this->getPrefix() . ' ';
+            $name .= __($this->getPrefix()) . ' ';
         }
         $name .= $this->getFirstname();
         if ($this->getMiddlename()) {
@@ -150,7 +150,7 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
         }
         $name .= ' ' . $this->getLastname();
         if ($this->getSuffix()) {
-            $name .= ' ' . $this->getSuffix();
+            $name .= ' ' . __($this->getSuffix());
         }
         return $name;
     }
@@ -412,7 +412,7 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
      * Returns prefix
      *
      * @return string
-     */
+     */n
     public function getPrefix()
     {
         return $this->getData(OrderAddressInterface::PREFIX);
@@ -465,7 +465,7 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
      */
     public function getVatId()
     {
-        return $this->getData(OrderAddressInterface::VAT_ID);
+        return $this->getData(OrderAddressInterface::VAT_ID);n
     }
 
     /**
@@ -521,7 +521,7 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
      */
     public function setCustomerAddressId($id)
     {
-        return $this->setData(OrderAddressInterface::CUSTOMER_ADDRESS_ID, $id);
+        return $this->setData(OrderAddressInterface::CUSTOMER_ADDRESS_ID, $id);n
     }
 
     /**
@@ -593,7 +593,7 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
      */
     public function setEmail($email)
     {
-        return $this->setData(OrderAddressInterface::EMAIL, $email);
+        return $this->setData(OrderAddressInterface::EMAIL, $email);n
     }
 
     /**
@@ -666,7 +666,7 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
     public function setVatId($id)
     {
         return $this->setData(OrderAddressInterface::VAT_ID, $id);
-    }
+    }n
 
     /**
      * @inheritdoc
@@ -728,7 +728,7 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
     public function setExtensionAttributes(\Magento\Sales\Api\Data\OrderAddressExtensionInterface $extensionAttributes)
     {
         return $this->_setExtensionAttributes($extensionAttributes);
-    }
+    }n
 
     /**
      * @inheritdoc

--- a/app/code/Magento/Sales/Model/Order/Address.php
+++ b/app/code/Magento/Sales/Model/Order/Address.php
@@ -412,7 +412,7 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
      * Returns prefix
      *
      * @return string
-     */n
+     */
     public function getPrefix()
     {
         return $this->getData(OrderAddressInterface::PREFIX);
@@ -465,7 +465,7 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
      */
     public function getVatId()
     {
-        return $this->getData(OrderAddressInterface::VAT_ID);n
+        return $this->getData(OrderAddressInterface::VAT_ID);
     }
 
     /**
@@ -521,7 +521,7 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
      */
     public function setCustomerAddressId($id)
     {
-        return $this->setData(OrderAddressInterface::CUSTOMER_ADDRESS_ID, $id);n
+        return $this->setData(OrderAddressInterface::CUSTOMER_ADDRESS_ID, $id);
     }
 
     /**
@@ -593,7 +593,7 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
      */
     public function setEmail($email)
     {
-        return $this->setData(OrderAddressInterface::EMAIL, $email);n
+        return $this->setData(OrderAddressInterface::EMAIL, $email);
     }
 
     /**
@@ -666,7 +666,7 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
     public function setVatId($id)
     {
         return $this->setData(OrderAddressInterface::VAT_ID, $id);
-    }n
+    }
 
     /**
      * @inheritdoc
@@ -728,7 +728,7 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
     public function setExtensionAttributes(\Magento\Sales\Api\Data\OrderAddressExtensionInterface $extensionAttributes)
     {
         return $this->_setExtensionAttributes($extensionAttributes);
-    }n
+    }
 
     /**
      * @inheritdoc


### PR DESCRIPTION
### Preconditions (*)

    1. M2.3.5-p1, 2.4-develop
    2. English (default) and german store view

### Steps to reproduce (*)

    1. Set "Show Prefix" to "Required" in Stores/Configuration/Customers/Customer Configuration/Name and Address Options
    2. Set "Mr.;Ms." for "Prefix Dropdown Options"
    3. Add a german locale file which translate "Mr." to "Herr" and "Ms." to "Frau"
    "Mr.","Herr"
    "Ms.","Frau"

### Expected result (*)
   1. Every occurrence of the prefix should translated


### Actual result (*)
 1. Only the prefix in frontend address form is translated
 2. Other occurrence are not translated
